### PR TITLE
Kuechenfunk

### DIFF
--- a/zones/0.0.0.0.4.a.3.9.8.a.5.6.0.0.d.f.ip6.arpa
+++ b/zones/0.0.0.0.4.a.3.9.8.a.5.6.0.0.d.f.ip6.arpa
@@ -1,28 +1,31 @@
 $ORIGIN 0.0.0.0.4.a.3.9.8.a.5.6.0.0.d.f.ip6.arpa.
 
 $TTL 3600
-@				IN	SOA	ns.fffd. hostmaster.fffd. (
-						2015100003	; serial
-						10800		; refresh
-						3600		; retry
-						604800		; expire
-						3600		; ttl
-						)
+@					IN	SOA	ns.fffd. hostmaster.fffd. (
+							2015100003	; serial
+							10800		; refresh
+							3600		; retry
+							604800		; expire
+							3600		; ttl
+							)
 
-;@				IN	NS 	ns1.fffd.
-@				IN	NS 	ns2.fffd.
-@				IN	NS 	ns3.fffd.
+;@					IN	NS 	ns1.fffd.
+@					IN	NS 	ns2.fffd.
+@					IN	NS 	ns3.fffd.
 
-5.5.2.0.0.0.0.0.0.0.0.0.0.0.0.0	IN	PTR	nextnode.fffd.
+5.5.2.0.0.0.0.0.0.0.0.0.0.0.0.0		IN	PTR	nextnode.fffd.
 
-1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0	IN	PTR	gw01.services.fffd.
-2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0	IN	PTR	gw02.services.fffd.
-3.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0	IN	PTR	gw03.services.fffd.
+1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0		IN	PTR	gw01.services.fffd.
+2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0		IN	PTR	gw02.services.fffd.
+3.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0		IN	PTR	gw03.services.fffd.
 
 
-1.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0	IN	PTR	srv1.services.fffd.
+1.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0		IN	PTR	srv1.services.fffd.
 
-2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0	IN	PTR	nms.services.fffd.
+2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0		IN	PTR	nms.services.fffd.
 
-3.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0	IN	PTR	srv2.services.fffd.
+3.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0		IN	PTR	srv2.services.fffd.
+
+
+50.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0	IN	PTR	kuechenfunk.fffd.
 

--- a/zones/0.185.10.in-addr.arpa
+++ b/zones/0.185.10.in-addr.arpa
@@ -23,4 +23,4 @@ $TTL 3600
 11			IN	PTR	srv1.services.fffd.
 12			IN	PTR	nms.services.fffd.
 13			IN	PTR	srv2.services.fffd.
-
+50			IN	PTR	kuechenfunk.fffd.

--- a/zones/db.fffd
+++ b/zones/db.fffd
@@ -51,6 +51,9 @@ mumble			IN	A	10.185.0.11
 
 academy			IN	A	10.185.1.42
 
+kuechenfunk		IN	A	10.185.1.50
+			IN	AAAA	fd00:65a8:93a4::1:50
+
 hs-fulda		IN	A	10.185.1.23
 *.hs-fulda		IN	A	10.185.1.23
 


### PR DESCRIPTION
Ich habe die v4 und v6 IP des Küchenfunks hinzugefügt.
Was ist nicht weiß ist, ob man auch 'ü's nutzen kann. Daher habe ich 'ue' gewählt.
