### PR TITLE
added freishare and ipv6 for hs-fulda

### DIFF
--- a/zones/db.fffd.eu
+++ b/zones/db.fffd.eu
@@ -54,8 +54,20 @@ mumble			IN	A	10.185.0.11
 
 
 
+freishare		IN	A	10.185.1.10
+			IN	AAAA	fd00:65a8:93a4::1:10
+
+tracker1		IN	A	10.185.1.11
+			IN	AAAA	fd00:65a8:93a4::1:11
+
+tracker2		IN	A	10.185.1.12
+			IN	AAAA	fd00:65a8:93a4::1:12
+
 hs-fulda		IN	A	10.185.1.23
+			IN	AAAA	fd00:65a8:93a4::1:23
+
 *.hs-fulda		IN	A	10.185.1.23
+			IN	AAAA	fd00:65a8:93a4::1:23
 
 academy			IN	A	10.185.1.42
 

--- a/zones/db.fffd.eu
+++ b/zones/db.fffd.eu
@@ -2,7 +2,7 @@ $ORIGIN fffd.eu.
 $TTL 3600
 
 @ 			IN	SOA	ns.fffd.eu. hostmaster.fffd.eu. (
-					2015100006	; serial
+					2015100007	; serial
 					86400		; refresh
 					7200		; retry
 					3600000		; expire


### PR DESCRIPTION
DNS-Eintrage für die Bereitstellung einer Torrent Index Seite (freishare) und zwei Torrent Trackern um internes Filesharing mit BitTorrent zu ermöglichen.

Zusätzlich noch das Erweitern des DNS-Eintrags für hs-fulda um IPv6 Adressen
